### PR TITLE
Add support for 3.1.x definitions and add error handling for swagger definitions

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v2
       - name: Ballerina Build
-        uses: ballerina-platform/ballerina-action@nightly
+        uses: ballerina-platform/ballerina-action@2201.8.6
         with:
           args:
             build
@@ -26,7 +26,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v2
       - name: Ballerina Tests
-        uses: ballerina-platform/ballerina-action@nightly
+        uses: ballerina-platform/ballerina-action@2201.8.6
         with:
           args:
             test --code-coverage

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -2,7 +2,7 @@
 distribution = "2201.8.4"
 org = "wso2"
 name = "ai.agent"
-version = "0.7.6"
+version = "0.7.7"
 license = ["Apache-2.0"]
 authors = ["Ballerina"]
 keywords = ["AI/Agent", "Cost/Freemium"]

--- a/ballerina/openapi_utils.bal
+++ b/ballerina/openapi_utils.bal
@@ -72,10 +72,10 @@ HttpApiSpecification & readonly|error {
 # + return - A OpenApiSpec object
 public isolated function parseOpenApiSpec(map<json> openApiSpec) returns OpenApiSpec|UnsupportedOpenApiVersion|OpenApiParsingError {
     if !openApiSpec.hasKey("openapi") {
-        return error UnsupportedOpenApiVersion("OpenAPI version is not specified in the specification.");
+        return error UnsupportedOpenApiVersion("Unsupported API definition. Supports specifications with version 3.x.x only.");
     }
     json version = openApiSpec.get("openapi");
-    if version !is string || !version.matches(re `3\.0\..`) {
+    if version !is string || !version.matches(re `3\.(0|1)\..`) {
         return error UnsupportedOpenApiVersion("Unsupported OpenAPI version. Supports specifications with version 3.x.x only.");
     }
     OpenApiSpec|error parseSpec = openApiSpec.cloneWithType();


### PR DESCRIPTION
## Purpose

This PR addresses the following:
- Accepts OpenAPI 3.1.x definitions
- Modifies error message that'll be returned for swagger definitions

## Related Issue

- https://github.com/wso2/api-manager/issues/2835
