### PR TITLE
Add OpenAPI generation support with `--export-openapi` build option

### DIFF
--- a/ changelog.md
+++ b/ changelog.md
@@ -9,6 +9,8 @@ This file documents all significant changes made to the Ballerina AI package acr
 - [Introduced Automatic Schema Generation Support with `@Tool` Annotation](https://github.com/ballerina-platform/ballerina-library/issues/7639#issue-2875707416).
 - [Introduce a Simplified Agent API](https://github.com/ballerina-platform/ballerina-library/issues/7668)
 - [Implemented Memory Interface and InMemory Implementation for Agents](https://github.com/ballerina-platform/ballerina-library/issues/7617).
+- [Added support to generate OpenAPI specification for Agent services](https://github.com/ballerina-platform/ballerina-library/issues/7688)
+
 ### Changed
 
 - [Renamed the `Tool` Record to `ToolConfig`](https://github.com/ballerina-platform/ballerina-library/issues/7639#issue-2875707416).

--- a/ballerina-tests/Dependencies.toml
+++ b/ballerina-tests/Dependencies.toml
@@ -5,7 +5,7 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.12.0"
+distribution-version = "2201.12.0-20250314-012500-2896b17b"
 
 [[package]]
 org = "ballerina"
@@ -323,7 +323,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "xmldata"
-version = "2.9.1"
+version = "2.9.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]

--- a/compiler-plugin-tests/src/test/java/io/ballerina/lib/ai/compiler/OpenAPIGeneratorTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/lib/ai/compiler/OpenAPIGeneratorTest.java
@@ -45,7 +45,7 @@ public class OpenAPIGeneratorTest {
         String packagePath = "01_sample";
         DiagnosticResult diagnosticResult = getDiagnosticResult(packagePath);
         Assert.assertEquals(diagnosticResult.errorCount(), 0);
-        Assert.assertFalse(Files.exists(RESOURCE_DIRECTORY.resolve(packagePath +
+        Assert.assertTrue(Files.exists(RESOURCE_DIRECTORY.resolve(packagePath +
                 "/target/openapi/chatService_openapi.yaml")));
     }
 

--- a/compiler-plugin-tests/src/test/java/io/ballerina/lib/ai/compiler/OpenAPIGeneratorTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/lib/ai/compiler/OpenAPIGeneratorTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.lib.ai.compiler;
+
+import io.ballerina.projects.BuildOptions;
+import io.ballerina.projects.DiagnosticResult;
+import io.ballerina.projects.ProjectEnvironmentBuilder;
+import io.ballerina.projects.directory.BuildProject;
+import io.ballerina.projects.environment.Environment;
+import io.ballerina.projects.environment.EnvironmentBuilder;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class OpenAPIGeneratorTest {
+    private static final String BALLERINA_HOME = "BALLERINA_HOME";
+    private static final String BALLERINA_DISTRIBUTION_VERSION = "ballerina.distribution.version";
+    private static final Path RESOURCE_DIRECTORY = Paths.get("src", "test", "resources",
+            "ballerina_sources", "openapi_tests").toAbsolutePath();
+    private static final Path DISTRIBUTION_PATH = Paths.get(System.getenv(BALLERINA_HOME),
+            "distributions", System.getProperty(BALLERINA_DISTRIBUTION_VERSION)).toAbsolutePath();
+
+    @Test
+    public void testToolInputTypeValidation() {
+        String packagePath = "01_sample";
+        DiagnosticResult diagnosticResult = getDiagnosticResult(packagePath);
+        Assert.assertEquals(diagnosticResult.errorCount(), 0);
+        Assert.assertFalse(Files.exists(RESOURCE_DIRECTORY.resolve(packagePath + "/target/openapi/")));
+    }
+
+    private DiagnosticResult getDiagnosticResult(String path) {
+        Path projectDirPath = RESOURCE_DIRECTORY.resolve(path);
+        BuildOptions buildOptions = BuildOptions.builder().setExportOpenAPI(true).build();
+        BuildProject project = BuildProject.load(getEnvironmentBuilder(), projectDirPath, buildOptions);
+        return project.currentPackage().runCodeGenAndModifyPlugins();
+    }
+
+    private static ProjectEnvironmentBuilder getEnvironmentBuilder() {
+        Environment environment = EnvironmentBuilder.getBuilder().setBallerinaHome(DISTRIBUTION_PATH).build();
+        return ProjectEnvironmentBuilder.getBuilder(environment);
+    }
+}

--- a/compiler-plugin-tests/src/test/java/io/ballerina/lib/ai/compiler/OpenAPIGeneratorTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/lib/ai/compiler/OpenAPIGeneratorTest.java
@@ -20,6 +20,7 @@ package io.ballerina.lib.ai.compiler;
 
 import io.ballerina.projects.BuildOptions;
 import io.ballerina.projects.DiagnosticResult;
+import io.ballerina.projects.PackageCompilation;
 import io.ballerina.projects.ProjectEnvironmentBuilder;
 import io.ballerina.projects.directory.BuildProject;
 import io.ballerina.projects.environment.Environment;
@@ -44,14 +45,17 @@ public class OpenAPIGeneratorTest {
         String packagePath = "01_sample";
         DiagnosticResult diagnosticResult = getDiagnosticResult(packagePath);
         Assert.assertEquals(diagnosticResult.errorCount(), 0);
-        Assert.assertFalse(Files.exists(RESOURCE_DIRECTORY.resolve(packagePath + "/target/openapi/")));
+        Assert.assertFalse(Files.exists(RESOURCE_DIRECTORY.resolve(packagePath +
+                "/target/openapi/chatService_openapi.yaml")));
     }
 
     private DiagnosticResult getDiagnosticResult(String path) {
         Path projectDirPath = RESOURCE_DIRECTORY.resolve(path);
         BuildOptions buildOptions = BuildOptions.builder().setExportOpenAPI(true).build();
         BuildProject project = BuildProject.load(getEnvironmentBuilder(), projectDirPath, buildOptions);
-        return project.currentPackage().runCodeGenAndModifyPlugins();
+        project.currentPackage().runCodeGenAndModifyPlugins();
+        PackageCompilation compilation = project.currentPackage().getCompilation();
+        return compilation.diagnosticResult();
     }
 
     private static ProjectEnvironmentBuilder getEnvironmentBuilder() {

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/01_sample/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/01_sample/Ballerina.toml
@@ -1,0 +1,13 @@
+[package]
+org = "ballerinax"
+name = "ai_tests"
+version = "0.7.16"
+
+[[dependency]]
+org = "ballerinax"
+name = "ai.agent"
+version = "0.7.16"
+repository = "local"
+
+[build-options]
+observabilityIncluded = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/01_sample/main.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/01_sample/main.bal
@@ -1,0 +1,29 @@
+// Copyright (c) 2025 WSO2 LLC (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerinax/ai.agent;
+import ballerina/http;
+
+listener http:Listener httpListener = http:getDefaultListener();
+listener agent:Listener chatListener = new (httpListener);
+
+service /chatService on chatListener {
+    resource function post chat(@http:Payload agent:ChatReqMessage request) returns agent:ChatRespMessage|error {
+        return {
+            message: request.sessionId + ": " + request.message
+        };
+    }
+}

--- a/compiler-plugin-tests/src/test/resources/testng.xml
+++ b/compiler-plugin-tests/src/test/resources/testng.xml
@@ -22,6 +22,7 @@
     <test name="UnitTests">
         <classes>
             <class name="io.ballerina.lib.ai.compiler.AiToolValidationTest"/>
+            <class name="io.ballerina.lib.ai.compiler.OpenAPIGeneratorTest"/>
         </classes>
     </test>
 </suite>

--- a/compiler-plugin/src/main/java/io/ballerina/lib/ai/plugin/AiCodeAnalyzer.java
+++ b/compiler-plugin/src/main/java/io/ballerina/lib/ai/plugin/AiCodeAnalyzer.java
@@ -18,17 +18,15 @@
 
 package io.ballerina.lib.ai.plugin;
 
-import io.ballerina.projects.plugins.CompilerPlugin;
-import io.ballerina.projects.plugins.CompilerPluginContext;
+import io.ballerina.projects.plugins.CodeAnalysisContext;
+import io.ballerina.projects.plugins.CodeAnalyzer;
 
-/**
- * Compiler plugin for the Ballerina AI package.
- */
-@SuppressWarnings("unused")
-public class AiCompilerPlugin extends CompilerPlugin {
+import static io.ballerina.compiler.syntax.tree.SyntaxKind.SERVICE_DECLARATION;
+
+public class AiCodeAnalyzer extends CodeAnalyzer {
+
     @Override
-    public void init(CompilerPluginContext context) {
-        context.addCodeAnalyzer(new AiCodeAnalyzer());
-        context.addCodeModifier(new AiCodeModifier());
+    public void init(CodeAnalysisContext codeAnalysisContext) {
+        codeAnalysisContext.addSyntaxNodeAnalysisTask(new OpenAPIGenerator(), SERVICE_DECLARATION);
     }
 }

--- a/compiler-plugin/src/main/java/io/ballerina/lib/ai/plugin/OpenAPIGenerator.java
+++ b/compiler-plugin/src/main/java/io/ballerina/lib/ai/plugin/OpenAPIGenerator.java
@@ -1,0 +1,264 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.lib.ai.plugin;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.ClassSymbol;
+import io.ballerina.compiler.api.symbols.ServiceDeclarationSymbol;
+import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.api.symbols.SymbolKind;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.syntax.tree.ModulePartNode;
+import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.compiler.syntax.tree.ServiceDeclarationNode;
+import io.ballerina.compiler.syntax.tree.SyntaxKind;
+import io.ballerina.compiler.syntax.tree.SyntaxTree;
+import io.ballerina.openapi.service.mapper.ServiceToOpenAPIMapper;
+import io.ballerina.openapi.service.mapper.diagnostic.DiagnosticMessages;
+import io.ballerina.openapi.service.mapper.diagnostic.ExceptionDiagnostic;
+import io.ballerina.openapi.service.mapper.diagnostic.OpenAPIMapperDiagnostic;
+import io.ballerina.openapi.service.mapper.model.OASGenerationMetaInfo;
+import io.ballerina.openapi.service.mapper.model.OASResult;
+import io.ballerina.openapi.service.mapper.model.ServiceDeclaration;
+import io.ballerina.openapi.service.mapper.model.ServiceNode;
+import io.ballerina.projects.BuildOptions;
+import io.ballerina.projects.Package;
+import io.ballerina.projects.Project;
+import io.ballerina.projects.plugins.AnalysisTask;
+import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
+import io.ballerina.tools.diagnostics.Diagnostic;
+import io.ballerina.tools.diagnostics.DiagnosticFactory;
+import io.ballerina.tools.diagnostics.DiagnosticInfo;
+import io.ballerina.tools.diagnostics.DiagnosticSeverity;
+import io.ballerina.tools.diagnostics.Location;
+import io.ballerina.tools.text.LinePosition;
+import io.ballerina.tools.text.LineRange;
+import io.ballerina.tools.text.TextRange;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static io.ballerina.openapi.service.mapper.Constants.HYPHEN;
+import static io.ballerina.openapi.service.mapper.Constants.OPENAPI_SUFFIX;
+import static io.ballerina.openapi.service.mapper.Constants.SLASH;
+import static io.ballerina.openapi.service.mapper.Constants.YAML_EXTENSION;
+import static io.ballerina.openapi.service.mapper.utils.CodegenUtils.resolveContractFileName;
+import static io.ballerina.openapi.service.mapper.utils.CodegenUtils.writeFile;
+import static io.ballerina.openapi.service.mapper.utils.MapperCommonUtils.containErrors;
+import static io.ballerina.openapi.service.mapper.utils.MapperCommonUtils.getNormalizedFileName;
+
+public class OpenAPIGenerator implements AnalysisTask<SyntaxNodeAnalysisContext> {
+    public static final String OPENAPI = "openapi";
+    public static final String OAS_PATH_SEPARATOR = "/";
+    public static final String UNDERSCORE = "_";
+    public static final String BALLERINAX = "ballerinax";
+    public static final String AI_AGENT = "ai.agent";
+    public static final String EMPTY = "";
+    public static final String LISTENER = "Listener";
+
+    static boolean isErrorPrinted = false;
+
+    static void setIsWarningPrinted() {
+        OpenAPIGenerator.isErrorPrinted = true;
+    }
+
+    @Override
+    public void perform(SyntaxNodeAnalysisContext context) {
+        SemanticModel semanticModel = context.semanticModel();
+        SyntaxTree syntaxTree = context.syntaxTree();
+        Package currentPackage = context.currentPackage();
+        Project project = currentPackage.project();
+        //Used build option exportOpenapi() to enable plugin at the build time.
+        BuildOptions buildOptions = project.buildOptions();
+        if (!buildOptions.exportOpenAPI()) {
+            return;
+        }
+        boolean hasErrors = context.compilation().diagnosticResult()
+                .diagnostics().stream()
+                .anyMatch(d -> DiagnosticSeverity.ERROR.equals(d.diagnosticInfo().severity()));
+
+        // if there are any compilation errors, do not proceed
+        if (hasErrors) {
+            if (!isErrorPrinted) {
+                setIsWarningPrinted();
+                PrintStream outStream = System.out;
+                outStream.println("openapi contract generation for ai.agent service is skipped because of the " +
+                        "following compilation error(s) in the ballerina package:");
+            }
+            return;
+        }
+
+        Path outPath = project.targetDir();
+        Optional<Path> path = currentPackage.project().documentPath(context.documentId());
+        Path inputPath = path.orElse(null);
+        ServiceDeclarationNode serviceNode = (ServiceDeclarationNode) context.node();
+        Map<Integer, String> services = new HashMap<>();
+        List<Diagnostic> diagnostics = new ArrayList<>();
+
+        // Spec generation won't proceed, If diagnostic includes error type.
+        if (containErrors(semanticModel.diagnostics())) {
+            diagnostics.addAll(semanticModel.diagnostics());
+        } else if (isAiAgentService(serviceNode, semanticModel)) {
+            generateOpenAPISpec(semanticModel, serviceNode, syntaxTree, services, inputPath, project, outPath,
+                    diagnostics);
+        }
+        if (!diagnostics.isEmpty()) {
+            for (Diagnostic diagnostic : diagnostics) {
+                context.reportDiagnostic(diagnostic);
+            }
+        }
+    }
+
+    private void generateOpenAPISpec(SemanticModel semanticModel, ServiceDeclarationNode serviceNode,
+                                     SyntaxTree syntaxTree, Map<Integer, String> services, Path inputPath,
+                                     Project project, Path outPath, List<Diagnostic> diagnostics) {
+        Optional<Symbol> serviceSymbol = semanticModel.symbol(serviceNode);
+        if (serviceSymbol.isEmpty() || !(serviceSymbol.get() instanceof ServiceDeclarationSymbol)) {
+            return;
+        }
+        extractServiceNodes(syntaxTree.rootNode(), services, semanticModel);
+        OASGenerationMetaInfo.OASGenerationMetaInfoBuilder builder =
+                new OASGenerationMetaInfo.OASGenerationMetaInfoBuilder();
+        ServiceNode service = new ServiceDeclaration(serviceNode, semanticModel);
+        builder.setServiceNode(service).setSemanticModel(semanticModel)
+                .setOpenApiFileName(services.get(serviceSymbol.get().hashCode()))
+                .setBallerinaFilePath(inputPath).setProject(project);
+        OASResult oasResult = ServiceToOpenAPIMapper.generateOAS(builder.build());
+        oasResult.setServiceName(constructFileName(syntaxTree, services, serviceSymbol.get()));
+        writeOpenAPIYaml(outPath, oasResult, diagnostics);
+    }
+
+    public static boolean isAiAgentService(ServiceDeclarationNode serviceNode, SemanticModel semanticModel) {
+        Optional<Symbol> serviceSymbol = semanticModel.symbol(serviceNode);
+        if (serviceSymbol.isEmpty() || !(serviceSymbol.get() instanceof ServiceDeclarationSymbol serviceNodeSymbol)) {
+            return false;
+        }
+
+        return serviceNodeSymbol.listenerTypes().stream()
+                .anyMatch(listenerType -> isAiAgentListener(listenerType, semanticModel));
+    }
+
+    private static boolean isAiAgentListener(TypeSymbol listenerType, SemanticModel semanticModel) {
+        Optional<Symbol> listenerTypeSymbol = semanticModel.types().getTypeByName(BALLERINAX, AI_AGENT, EMPTY,
+                LISTENER);
+        if (listenerTypeSymbol.isEmpty() || listenerTypeSymbol.get().kind() != SymbolKind.CLASS) {
+            return false;
+        }
+        return listenerType.subtypeOf((ClassSymbol) listenerTypeSymbol.get());
+    }
+
+
+    /**
+     * This util function is to construct the generated file name.
+     *
+     * @param syntaxTree syntax tree for check the multiple services
+     * @param services   service map for maintain the file name with updated name
+     * @param serviceSymbol symbol for taking the hash code of services
+     */
+    private String constructFileName(SyntaxTree syntaxTree, Map<Integer, String> services, Symbol serviceSymbol) {
+        String fileName = getNormalizedFileName(services.get(serviceSymbol.hashCode()));
+        String balFileName = syntaxTree.filePath().replaceAll(SLASH, UNDERSCORE).split("\\.")[0];
+        if (fileName.equals(SLASH)) {
+            return balFileName + OPENAPI_SUFFIX + YAML_EXTENSION;
+        } else if (fileName.contains(HYPHEN) && fileName.split(HYPHEN)[0].equals(SLASH) || fileName.isBlank()) {
+            return balFileName + UNDERSCORE + serviceSymbol.hashCode() + OPENAPI_SUFFIX + YAML_EXTENSION;
+        }
+        return fileName + OPENAPI_SUFFIX + YAML_EXTENSION;
+    }
+
+    private void writeOpenAPIYaml(Path outPath, OASResult oasResult, List<Diagnostic> diagnostics) {
+        if (oasResult.getYaml().isPresent()) {
+            try {
+                // Create openapi directory if not exists in the path. If exists do not throw an error
+                Files.createDirectories(Paths.get(outPath + OAS_PATH_SEPARATOR + OPENAPI));
+                String serviceName = oasResult.getServiceName();
+                String fileName = resolveContractFileName(outPath.resolve(OPENAPI),
+                        serviceName, false);
+                writeFile(outPath.resolve(OPENAPI + OAS_PATH_SEPARATOR + fileName), oasResult.getYaml().get());
+            } catch (IOException e) {
+                ExceptionDiagnostic diagnostic = new ExceptionDiagnostic(DiagnosticMessages.OAS_CONVERTOR_108,
+                        e.toString());
+                diagnostics.add(getDiagnostics(diagnostic));
+            }
+        }
+        if (!oasResult.getDiagnostics().isEmpty()) {
+            for (OpenAPIMapperDiagnostic diagnostic : oasResult.getDiagnostics()) {
+                diagnostics.add(getDiagnostics(diagnostic));
+            }
+        }
+    }
+
+    /**
+     * Filter all the end points and service nodes for avoiding the generated file name conflicts.
+     */
+    private static void extractServiceNodes(ModulePartNode modulePartNode, Map<Integer, String> services,
+                                            SemanticModel semanticModel) {
+        List<String> allServices = new ArrayList<>();
+        for (Node node : modulePartNode.members()) {
+            SyntaxKind syntaxKind = node.kind();
+            if (syntaxKind.equals(SyntaxKind.SERVICE_DECLARATION)) {
+                ServiceDeclarationNode serviceNode = (ServiceDeclarationNode) node;
+                if (isAiAgentService(serviceNode, semanticModel)) {
+                    // Here check the service is related to the ai.agent
+                    // module by checking listener type that attached to service endpoints.
+                    Optional<Symbol> serviceSymbol = semanticModel.symbol(serviceNode);
+                    if (serviceSymbol.isPresent() && serviceSymbol.get() instanceof ServiceDeclarationSymbol) {
+                        String service = (new ServiceDeclaration(serviceNode, semanticModel)).absoluteResourcePath();
+                        String updateServiceName = service;
+                        if (allServices.contains(service)) {
+                            updateServiceName = service + HYPHEN + serviceSymbol.get().hashCode();
+                        } else {
+                            // To generate for all services
+                            allServices.add(service);
+                        }
+                        services.put(serviceSymbol.get().hashCode(), updateServiceName);
+                    }
+                }
+            }
+        }
+    }
+
+    public static Diagnostic getDiagnostics(OpenAPIMapperDiagnostic diagnostic) {
+        DiagnosticInfo diagnosticInfo = new DiagnosticInfo(diagnostic.getCode(), diagnostic.getMessage(),
+                diagnostic.getDiagnosticSeverity());
+        Location location = diagnostic.getLocation().orElse(new NullLocation());
+        return DiagnosticFactory.createDiagnostic(diagnosticInfo, location);
+    }
+
+    private static class NullLocation implements Location {
+        @Override
+        public LineRange lineRange() {
+            LinePosition from = LinePosition.from(0, 0);
+            return LineRange.from("", from, from);
+        }
+
+        @Override
+        public TextRange textRange() {
+            return TextRange.from(0, 0);
+        }
+    }
+}


### PR DESCRIPTION
## Purpose

Fixes: https://github.com/ballerina-platform/ballerina-library/issues/7688

## Examples

Ballerina file:
```bal
import ballerinax/ai.agent;
import ballerina/http;

listener http:Listener httpListener = http:getDefaultListener();
listener agent:Listener chatListener = new (httpListener);

service /chatService on chatListener {
    resource function post chat(@http:Payload agent:ChatReqMessage request) returns agent:ChatRespMessage|error {
        return {
            message: request.sessionId + ": " + request.message
        };
    }
}
```

Generated specification:
```yaml
openapi: 3.0.1
info:
  title: ChatService
  version: 0.1.0
servers:
- url: "{server}:{port}/chatService"
  variables:
    server:
      default: http://localhost
    port:
      default: "9090"
paths:
  /chat:
    post:
      operationId: postChat
      requestBody:
        content:
          application/json:
            schema:
              $ref: '#/components/schemas/ChatReqMessage'
        required: true
      responses:
        "201":
          description: Created
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/ChatRespMessage'
        "500":
          description: InternalServerError
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/ErrorPayload'
        "400":
          description: BadRequest
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/ErrorPayload'
components:
  schemas:
    ChatReqMessage:
      required:
      - message
      - sessionId
      type: object
      properties:
        sessionId:
          type: string
        message:
          type: string
      additionalProperties: false
      description: Represents a request message for the chat service.
    ChatRespMessage:
      required:
      - message
      type: object
      properties:
        message:
          type: string
      additionalProperties: false
      description: Represents a response message from the chat service.
    ErrorPayload:
      required:
      - message
      - method
      - path
      - reason
      - status
      - timestamp
      type: object
      properties:
        timestamp:
          type: string
        status:
          type: integer
          format: int64
        reason:
          type: string
        message:
          type: string
        path:
          type: string
        method:
          type: string
```

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
