### PR TITLE
Fix OpenAPI generation for anonymous listener attachment via new statement

### DIFF
--- a/ballerina-tests/Ballerina.toml
+++ b/ballerina-tests/Ballerina.toml
@@ -1,12 +1,12 @@
 [package]
 org = "ballerinax"
 name = "ai_tests"
-version = "0.7.16"
+version = "0.7.17"
 
 [[dependency]]
 org = "ballerinax"
 name = "ai.agent"
-version = "0.7.16"
+version = "0.7.17"
 repository = "local"
 
 [build-options]

--- a/ballerina-tests/Dependencies.toml
+++ b/ballerina-tests/Dependencies.toml
@@ -5,7 +5,7 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.12.0"
+distribution-version = "2201.12.0-20250314-012500-2896b17b"
 
 [[package]]
 org = "ballerina"
@@ -355,7 +355,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "ai.agent"
-version = "0.7.16"
+version = "0.7.17"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "data.jsondata"},
@@ -382,7 +382,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "ai_tests"
-version = "0.7.16"
+version = "0.7.17"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "io"},

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -2,7 +2,7 @@
 distribution = "2201.12.0"
 org = "ballerinax"
 name = "ai.agent"
-version = "0.7.16"
+version = "0.7.17"
 license = ["Apache-2.0"]
 authors = ["Ballerina"]
 keywords = ["AI/Agent", "Cost/Freemium", "Agent", "AI"]
@@ -14,5 +14,5 @@ graalvmCompatible = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.lib"
 artifactId = "ai.agent-native"
-version = "0.7.16"
-path = "../native/build/libs/ai.agent-native-0.7.16.jar"
+version = "0.7.17"
+path = "../native/build/libs/ai.agent-native-0.7.17-SNAPSHOT.jar"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,7 +3,7 @@ id = "ai.agent-compiler-plugin"
 class = "io.ballerina.lib.ai.plugin.AiCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/ai.agent-compiler-plugin-0.7.16.jar"
+path = "../compiler-plugin/build/libs/ai.agent-compiler-plugin-0.7.17-SNAPSHOT.jar"
 
 [[dependency]]
 path = "../compiler-plugin/build/libs/ballerina-to-openapi-2.3.0.jar"

--- a/compiler-plugin-tests/src/test/java/io/ballerina/lib/ai/compiler/OpenAPIGeneratorTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/lib/ai/compiler/OpenAPIGeneratorTest.java
@@ -41,12 +41,21 @@ public class OpenAPIGeneratorTest {
             "distributions", System.getProperty(BALLERINA_DISTRIBUTION_VERSION)).toAbsolutePath();
 
     @Test
-    public void testToolInputTypeValidation() {
+    public void testOpenAPIGenerationForListenerVariable() {
         String packagePath = "01_sample";
         DiagnosticResult diagnosticResult = getDiagnosticResult(packagePath);
         Assert.assertEquals(diagnosticResult.errorCount(), 0);
         Assert.assertTrue(Files.exists(RESOURCE_DIRECTORY.resolve(packagePath +
                 "/target/openapi/chatService_openapi.yaml")));
+    }
+
+    @Test
+    public void testOpenAPIGenerationForAnonymousListener() {
+        String packagePath = "02_sample";
+        DiagnosticResult diagnosticResult = getDiagnosticResult(packagePath);
+        Assert.assertEquals(diagnosticResult.errorCount(), 0);
+        Assert.assertTrue(Files.exists(RESOURCE_DIRECTORY.resolve(packagePath +
+                "/target/openapi/api_v1_openapi.yaml")));
     }
 
     private DiagnosticResult getDiagnosticResult(String path) {

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/01_sample/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/01_sample/Ballerina.toml
@@ -1,12 +1,12 @@
 [package]
 org = "ballerinax"
 name = "ai_tests"
-version = "0.7.16"
+version = "0.7.17"
 
 [[dependency]]
 org = "ballerinax"
 name = "ai.agent"
-version = "0.7.16"
+version = "0.7.17"
 repository = "local"
 
 [build-options]

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/02_sample/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/02_sample/Ballerina.toml
@@ -1,0 +1,13 @@
+[package]
+org = "ballerinax"
+name = "ai_tests"
+version = "0.7.17"
+
+[[dependency]]
+org = "ballerinax"
+name = "ai.agent"
+version = "0.7.17"
+repository = "local"
+
+[build-options]
+observabilityIncluded = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/02_sample/main.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/02_sample/main.bal
@@ -1,0 +1,52 @@
+// Copyright (c) 2025 WSO2 LLC (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerinax/ai.agent;
+
+configurable string apiKey = ?;
+configurable string deploymentId = ?;
+configurable string apiVersion = ?;
+configurable string serviceUrl = ?;
+
+final agent:Model model = check new agent:AzureOpenAiModel(serviceUrl, apiKey, deploymentId, apiVersion);
+final agent:Agent agent = check new (
+    systemPrompt = {
+        role: "Math Tutor",
+        instructions: "You are a school tutor assistant. " +
+        "Provide answers to students' questions so they can compare their answers. " +
+        "Use the tools when there is query related to math"
+    },
+    model = model,
+    tools = [sum, mult, sqrt],
+    verbose = true
+);
+
+@agent:Tool
+isolated function sum(decimal a, decimal b) returns decimal => a + b;
+
+@agent:Tool
+isolated function mult(decimal a, decimal b) returns decimal => a * b;
+
+@agent:Tool
+isolated function sqrt(float a) returns float => a.sqrt();
+
+service /api/v1 on new agent:Listener(9090) {
+    resource function post chat(@http:Payload agent:ChatReqMessage request) returns agent:ChatRespMessage|error {
+        string response = check agent->run(request.message, memoryId = request.sessionId);
+        return {message: response};
+    }
+}

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/01_tool_with_any_input_type/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/01_tool_with_any_input_type/Ballerina.toml
@@ -1,12 +1,12 @@
 [package]
 org = "ballerinax"
 name = "ai_tests"
-version = "0.7.16"
+version = "0.7.17"
 
 [[dependency]]
 org = "ballerinax"
 name = "ai.agent"
-version = "0.7.16"
+version = "0.7.17"
 repository = "local"
 
 [build-options]

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/02_tool_with_any_return_type/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/02_tool_with_any_return_type/Ballerina.toml
@@ -1,12 +1,12 @@
 [package]
 org = "ballerinax"
 name = "ai_tests"
-version = "0.7.16"
+version = "0.7.17"
 
 [[dependency]]
 org = "ballerinax"
 name = "ai.agent"
-version = "0.7.16"
+version = "0.7.17"
 repository = "local"
 
 [build-options]

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/03_tool_with_xml_input_type/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/03_tool_with_xml_input_type/Ballerina.toml
@@ -1,12 +1,12 @@
 [package]
 org = "ballerinax"
 name = "ai_tests"
-version = "0.7.16"
+version = "0.7.17"
 
 [[dependency]]
 org = "ballerinax"
 name = "ai.agent"
-version = "0.7.16"
+version = "0.7.17"
 repository = "local"
 
 [build-options]

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/04_tool_with_cyclic_input_type/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/04_tool_with_cyclic_input_type/Ballerina.toml
@@ -1,12 +1,12 @@
 [package]
 org = "ballerinax"
 name = "ai_tests"
-version = "0.7.16"
+version = "0.7.17"
 
 [[dependency]]
 org = "ballerinax"
 name = "ai.agent"
-version = "0.7.16"
+version = "0.7.17"
 repository = "local"
 
 [build-options]

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/05_error_lines_no_change/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/05_error_lines_no_change/Ballerina.toml
@@ -1,12 +1,12 @@
 [package]
 org = "ballerinax"
 name = "ai_tests"
-version = "0.7.16"
+version = "0.7.17"
 
 [[dependency]]
 org = "ballerinax"
 name = "ai.agent"
-version = "0.7.16"
+version = "0.7.17"
 repository = "local"
 
 [build-options]

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/06_module_level_agent_without_final_qualifier/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/06_module_level_agent_without_final_qualifier/Ballerina.toml
@@ -1,12 +1,12 @@
 [package]
 org = "ballerinax"
 name = "ai_tests"
-version = "0.7.16"
+version = "0.7.17"
 
 [[dependency]]
 org = "ballerinax"
 name = "ai.agent"
-version = "0.7.16"
+version = "0.7.17"
 repository = "local"
 
 [build-options]

--- a/compiler-plugin/src/main/java/io/ballerina/lib/ai/plugin/OpenAPIGenerator.java
+++ b/compiler-plugin/src/main/java/io/ballerina/lib/ai/plugin/OpenAPIGenerator.java
@@ -158,17 +158,21 @@ public class OpenAPIGenerator implements AnalysisTask<SyntaxNodeAnalysisContext>
             return false;
         }
 
-        return serviceNodeSymbol.listenerTypes().stream()
-                .anyMatch(listenerType -> isAiAgentListener(listenerType, semanticModel));
-    }
-
-    private static boolean isAiAgentListener(TypeSymbol listenerType, SemanticModel semanticModel) {
         Optional<Symbol> listenerTypeSymbol = semanticModel.types().getTypeByName(BALLERINAX, AI_AGENT, EMPTY,
                 LISTENER);
         if (listenerTypeSymbol.isEmpty() || listenerTypeSymbol.get().kind() != SymbolKind.CLASS) {
             return false;
         }
-        return listenerType.subtypeOf((ClassSymbol) listenerTypeSymbol.get());
+
+        return serviceNodeSymbol.listenerTypes().stream()
+                .anyMatch(listenerType -> isAiAgentListener(listenerType,
+                        (ClassSymbol) listenerTypeSymbol.get()));
+    }
+
+    private static boolean isAiAgentListener(TypeSymbol listenerType, TypeSymbol aiAgentListenerType) {
+        // The listener type can be ai.agent:Listener for listener variable attachment
+        // or ai.agent:Listener|error for anonymous new listener attachment
+        return aiAgentListenerType.subtypeOf(listenerType);
     }
 
 


### PR DESCRIPTION
## Purpose

> $Subject

## Examples

OpenAPI will be generated for anonymous listener attachment via new statement as well:
```ballerina
service on new agent:Listener(9090) {
    resource function post chat(@http:Payload agent:ChatReqMessage request) returns agent:ChatRespMessage|error {
        string response = check agent->run(request.message, memoryId = request.sessionId);
        return {message: response};
    }
}
```

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
