### PR TITLE
Bump version from 1.1.1 to 1.1.2

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -2,7 +2,7 @@
 distribution = "2201.12.0"
 org = "ballerinax"
 name = "ai"
-version = "1.1.1"
+version = "1.1.2"
 license = ["Apache-2.0"]
 authors = ["Ballerina"]
 keywords = ["AI/Agent", "Cost/Freemium", "Agent", "AI"]
@@ -14,5 +14,5 @@ graalvmCompatible = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.lib"
 artifactId = "ai-native"
-version = "1.1.1"
-path = "../native/build/libs/ai-native-1.1.1-SNAPSHOT.jar"
+version = "1.1.2"
+path = "../native/build/libs/ai-native-1.1.2-SNAPSHOT.jar"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,7 +3,7 @@ id = "ai-compiler-plugin"
 class = "io.ballerina.lib.ai.plugin.AiCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/ai-compiler-plugin-1.1.1-SNAPSHOT.jar"
+path = "../compiler-plugin/build/libs/ai-compiler-plugin-1.1.2-SNAPSHOT.jar"
 
 [[dependency]]
 path = "../compiler-plugin/build/libs/ballerina-to-openapi-2.3.0.jar"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=io.ballerina.lib
-version=1.1.1-SNAPSHOT
+version=1.1.2-SNAPSHOT
 ballerinaLangVersion=2201.12.0
 
 checkstylePluginVersion=10.12.0


### PR DESCRIPTION
## Purpose
This PR updates the module version from `1.1.1` to `1.1.2`.
Resolves: [https://github.com/ballerina-platform/ballerina-library/issues/7955](https://github.com/ballerina-platform/ballerina-library/issues/7955)

## Examples

## Checklist
- [x] Linked to an issue

